### PR TITLE
优化插件启停模板

### DIFF
--- a/88-Template/tp/tp-插件启停模板.md
+++ b/88-Template/tp/tp-插件启停模板.md
@@ -1,69 +1,86 @@
 <%*
 // Form https://github.com/cumany/Blue-topaz-examples/issues/54  Thanks  **[hustrjh](https://github.com/hustrjh)**
 
-let myEn= await tp.system.suggester( ["启用", "停用","维护插件分组"], [1, 0,2],false,"选择需要进行的操作，启用插件还是禁用插件");
-let myChoice = await tp.system.suggester( ["编辑增强", "表格增强", "显示加强","除必备插件外", "全部",], ["Edit+", "Table+", "View+", "Required+","All"]);
+var funcArr = ["Edit+", "Table+", "View+"];
+let myEn = await tp.system.suggester(["🟢启用", "🔴停用", "🛠️插件分组"], [1, 0, 2], false, "选择操作，启用、禁用或管理插件");
 var i;
 var num;
+var item;
+var choice;
 var pluginArr = [];
+var tmpArr = [];
 -%>
 <%*
-
 //函数定义
-readlist = async (filename) => {
-if (tp.file.exists(filename)) {
-const f = tp.file.find_tfile(filename);
-let plugins = (await app.vault.read(f)).split(/\r?\n/);
-return plugins;
+ReadList = async (filename) => {
+    if (tp.file.exists(filename)) {
+        const f = tp.file.find_tfile(filename);
+        let plugins = (await app.vault.read(f)).split(/\r?\n/);
+        return plugins;
+    }
 }
-}
-fastSwitch = async (choice, en) => {
-	switch(choice)
-	{
-		case "Edit+":
-			//pluginArr.splice(0, 0, "editing-toolbar", "obsidian-outliner");
-            pluginArr = await readlist(choice);
-			break;
-		case "Table+":
-            pluginArr = await readlist(choice);
-			break;
-		case "View+":
-            pluginArr = await readlist(choice);
-			break;
-         case "Required+":
-            let AllpluginArr=Object.values(app.plugins.manifests).map(p=>p.id).sort((a,b)=>a.localeCompare(b))
-            let  RequiredArr = await readlist("Required+");
-            pluginArr = AllpluginArr.filter((x) => !RequiredArr.some((item) => x=== item));
+FastSwitch = async (en) => {
+    switch (en) {
+        case 2://编辑插件分组
+            choice = await tp.system.suggester(["📝编辑增强", "📝表格增强", "📝显示增强", "📝必备插件", "💼所有插件"], funcArr.concat(["Required+", "All"]), false, "编辑插件分组");
             break;
-		case "All":
-          let  pluginArr1 = await readlist("Edit+");
-          let  pluginArr2  = await readlist("Table+");
-          let  pluginArr3 = await readlist("View+");
-pluginArr=pluginArr.concat(pluginArr1,pluginArr2,pluginArr3)
-			break;
-	}
-	num = pluginArr.length;
-	switch(en)
-	{
-		case 1:
-			for(i=0;i<num;i++)
-			{
-				await app.plugins.enablePlugin(pluginArr[i]);
-			}
-			break;
-		case 0:
-			for(i=0;i<num;i++)
-			{
-				await app.plugins.disablePlugin(pluginArr[i]);
-			}
-			break;
-		case 2:
-		if(choice== "All") choice="获取插件列表"
-		const filePath = app.metadataCache.getFirstLinkpathDest(choice,'');
-	app.workspace.getUnpinnedLeaf().openFile(filePath);
-	break;
-	}
+        default://启停插件
+            choice = await tp.system.suggester(["📝编辑增强", "📝表格增强", "📝显示增强", "📝以上全部", "⚙更多操作"], funcArr.concat(["All", "actions"]), false, "启停插件");
+            break;
+    }
+    if (choice == "actions") {//更多操作
+        choice = await tp.system.suggester(["📝除编辑增强外", "📝除表格增强外", "📝除显示增强外", "📝除必备插件外", "💼所有插件",], funcArr.concat(["Required+", "All"]), false, "更多选项");
+        switch (choice) {
+            case "All":
+                pluginArr = await ReadList("示例库内置的插件列表");
+                break;
+            default:
+                let AllpluginArr = Object.values(app.plugins.manifests).map(p => p.id).sort((a, b) => a.localeCompare(b))
+                let RequiredArr = await ReadList(choice);
+                pluginArr = AllpluginArr.filter((x) => !RequiredArr.some((item) => x === item));
+                break;
+        }
+    }
+    else {//常规启停操作
+        switch (choice) {
+            case "All":
+                // for (let index = 0; index < funcArr.length; index++) {
+                //     const item = funcArr[index];
+                //     tmpArr = await ReadList(item);
+                //     pluginArr = pluginArr.concat(tmpArr);
+                //     }
+                for (const item of funcArr) {
+                    tmpArr = await ReadList(item);
+                    pluginArr = pluginArr.concat(tmpArr);
+                }
+                break;
+            default:
+                // pluginArr=pluginArr.concat(["editing-toolbar", "obsidian-outliner", "various-complements", "number-headings-obsidian"]);
+                pluginArr = await ReadList(choice);
+                break;
+        }
+    }
+    num = pluginArr.length;
+    switch (en) {
+        case 1:
+            for (i = 0; i < num; i++) {
+                await app.plugins.enablePlugin(pluginArr[i]);
+            }
+            new tp.obsidian.Notice("已启用插件组：" + choice, 3000);
+            break;
+        case 0:
+            for (i = 0; i < num; i++) {
+                await app.plugins.disablePlugin(pluginArr[i]);
+            }
+            new tp.obsidian.Notice("已禁用插件组：" + choice, 3000);
+            break;
+        case 2:
+            if (choice == "All") choice = "获取插件列表"
+            const filePath = app.metadataCache.getFirstLinkpathDest(choice, '');
+            app.workspace.getLeaf('tab').openFile(filePath);
+            break;
+    }
 }
 //函数调用
-await fastSwitch(myChoice, myEn);
+await FastSwitch(myEn);
 -%>


### PR DESCRIPTION
## 修改说明
1. 增加图标，方便区分选项。
![image](https://user-images.githubusercontent.com/69783980/210370650-1f87b12a-e31f-4825-b185-1e2849ea326f.png)
![image](https://user-images.githubusercontent.com/69783980/210370728-d6e0c75e-e4e0-4fab-9b7c-5972375ebf2c.png)
2. 新增数组，方便用户增加插件分组。
![image](https://user-images.githubusercontent.com/69783980/210370858-563a6de4-5443-449f-9135-221939ce7a50.png)
3. 新增的 **`以上全部`** 选项及程序，可自动将用户新增的分组合并操作。
![image](https://user-images.githubusercontent.com/69783980/210371063-35442dc9-a984-472c-a4f1-4ec73d7b9623.png)
![image](https://user-images.githubusercontent.com/69783980/210370948-96e851ed-cc50-41ae-9d92-ed047033c091.png)
![image](https://user-images.githubusercontent.com/69783980/210374397-784f1ce2-c1b4-4159-8f5d-2cfb5532a34e.png)
4. 新增 **`更多操作`** ，主要包含 **`除···外`** 和 **`所有插件`** 的启停操作，这里的所有是所有已装插件。
![image](https://user-images.githubusercontent.com/69783980/210371848-3f09e4be-5f5d-4bbf-8d14-503a911215e2.png)
![image](https://user-images.githubusercontent.com/69783980/210373931-ee2e3a46-2a15-4422-83c8-97cb1887c4b3.png)
5. 新增启停插件组的提示框，3s自动消失
![image](https://user-images.githubusercontent.com/69783980/210372166-7e2e8c64-135f-4517-b546-95889cc86756.png)
6. 改进开启编辑分组标签页的操作体验，在右侧打开，而不是左右拆分
![image](https://user-images.githubusercontent.com/69783980/210372263-2cd70d6f-945e-4a48-973b-72cca0e2a02d.png)
7. 新增操作提示信息
![image](https://user-images.githubusercontent.com/69783980/210372656-de353fd9-4f29-4c27-a317-5ac6765de700.png)
## 期望
还想把所有分组放在一个md文件，通过标题的方式区分和读取。这样用户编辑、修改和增加分组也会更加方便。但目前能力有限，暂时还做不到，仅能读取文件，还不能读取标题下内容。

这个插件启停模板的初衷是想在启动Obsidian时尽量少地启动插件、加快速度，同时减少一些占用内存大的插件影响使用Obsidian的流畅度，在需要某些功能时可以快速批量地启动相应插件。感谢大大将模板放进示例库中，我也希望把它改进地更好、更方便其他人使用。